### PR TITLE
Correct filename case in #include directives

### DIFF
--- a/src/hm01b0.cpp
+++ b/src/hm01b0.cpp
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#include "HM01B0.h"
+#include "hm01b0.h"
 #include "hm01b0_c/include/hm01b0_raw8_qvga_8bits_lsb_5fps.h"
 
 

--- a/src/hm01b0_c/include/hm01b0_raw8_qvga_8bits_lsb_5fps.h
+++ b/src/hm01b0_c/include/hm01b0_raw8_qvga_8bits_lsb_5fps.h
@@ -1,5 +1,5 @@
 
-#include "HM01B0.h"
+#include "hm01b0.h"
 
 const hm_script_t sHM01B0InitScript[] =
 {


### PR DESCRIPTION
Use of incorrect filename case causes compilation to fail on filename case-sensitive operating systems like Linux.